### PR TITLE
Fixes #1 - Compiler is not loaded in P7

### DIFF
--- a/src/QuickAccess-Core.package/QACAction.class/instance/execute.st
+++ b/src/QuickAccess-Core.package/QACAction.class/instance/execute.st
@@ -2,7 +2,7 @@ operating
 execute
 	|tail|
 	tail := ' executed'.
-	[ Compiler evaluate: self expression ] 
+	[ Smalltalk compiler evaluate: self expression ] 
 		on: Error 
 		do: [ tail := tail, ' with errors' ].
 	UIManager inform: self name, tail.


### PR DESCRIPTION
Use `Smalltalk compiler ` instead of `Compiler`.